### PR TITLE
Add fix for issue where textarea only shows 1 line initially

### DIFF
--- a/src/js/enhanced-textarea.jsx
+++ b/src/js/enhanced-textarea.jsx
@@ -63,7 +63,7 @@ var EnhancedTextarea = React.createClass({
           rows={this.props.rows}
           defaultValue={this.props.defaultValue}
           readOnly={true}
-          value={this.props.value} />
+          value={other.value} />
         <textarea
           {...other}
           ref="input"


### PR DESCRIPTION
If a TextArea starts with a large amount of text, it should immediately appear
with multiple rows in order to display all the text. Prior to this fix, the
TextArea would always appear with only 1 row if the value was set via ValueLink.
